### PR TITLE
Fix #65

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -118,7 +118,7 @@ func main() {
 				ClaveINE: "PIRP-00000000000000",
 				RFC: "PIRP-00000000000000",
 				Salario: 50.00,
-				Comisión: 10,
+				Comisiones: 10,
 				Estado: "Activo",
 				Usuario: "conductor",
 				Correo: "conductor@pirita.com",

--- a/backend/models/conductor.go
+++ b/backend/models/conductor.go
@@ -29,7 +29,7 @@ type Conductor struct {
 	Salario float64 `json:"salario"`
 
 	// Comisión es el porcentaje de comisión que se le aplica al conductor.
-	Comisión float64 `json:"comision"`
+	Comisiones float64 `json:"comisiones"`
 
 	// Estado es el estado en el que se encuentra el conductor. Puede ser
 	// "activo", "inactivo" o "suspendido".


### PR DESCRIPTION
### conductor.go & main.go: atributo comisiones actualizado
Se modificó el nombre del atributo para guardar las comisiones de *'comisión'* a *'comisiones'* para evitar problemas al migrar la base de datos